### PR TITLE
Fix DNS propagation issue and update readme

### DIFF
--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -98,6 +98,8 @@ Public network access is denied by default, meaning the only way to connect to t
 
 For instructions on how to connect securely from a local machine, please see internal Entur instructions.
 
+## Database instance sizing
+Basic (B) tier VM sizes are not supported (e.g. B_Gen4_1) as they lack support for private endpoint connections and geo-redundant backups.
 
 ## Inputs
 
@@ -123,7 +125,7 @@ For instructions on how to connect securely from a local machine, please see int
 | public_network_access_enabled | Whether to enable public network access | bool | false | no |
 | server_configurations | PostgreSQL configuration parameters | map(string) | N/A | no |
 | server_version | Specifies the version of PostgreSQL to use (e.g. "11")| string | N/A | yes |
-| sku_name | Specifies the SKU name for this PostgreSQL server (e.g. GP_Gen5_2) | string | N/A | yes |
+| sku_name | Specifies the SKU name for this PostgreSQL server ([more info](#database-instance-sizing)) | string | N/A | yes |
 | storage_mb | Max storage allowed for a server in megabytes (e.g. 5120) | number | N/A | yes |
 | tags | Tags to apply to created resources | map | N/A | yes |
 

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -76,7 +76,7 @@ variable "postgresql_server_name" {
 }
 
 variable "sku_name" {
-  description = "Specifies the SKU Name for this PostgreSQL Server. The name of the SKU, follows the tier + family + cores pattern (e.g. B_Gen4_1, GP_Gen5_8)."
+  description = "Specifies the SKU Name for this PostgreSQL Server. The name of the SKU, follows the tier + family + cores pattern (e.g. GP_Gen5_8) - note: Basic tier (B) VMs are not supported."
   type        = string
 }
 


### PR DESCRIPTION
Fixes issue with DNS record not being ready for use by PostgreSQL provider resources on first run. Now waits for 120s before proceeding when DNS records are created or updated. Tested using pipeline, verified OK. Fixes #4 

Updates variable description and readme to let users know basic tier VMs are not supported. Fixes #3
