### PR TITLE
removed destroy protection temporary

### DIFF
--- a/modules/postgresql-flex/main.tf
+++ b/modules/postgresql-flex/main.tf
@@ -62,7 +62,7 @@ resource "azurerm_postgresql_flexible_server" "main" {
   sku_name               = var.sku_name
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = false
   }
 }
 
@@ -140,7 +140,7 @@ resource "postgresql_schema" "schemas" {
   ]
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = false
   }
 }
 

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -46,7 +46,7 @@ resource "azurerm_postgresql_server" "main" {
   tags                             = var.tags
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = false
   }
 }
 


### PR DESCRIPTION
Removing destroy protection temporary in order to be able to delete singleserver and create flexible-server instead, for one of the project.