### PR TITLE
adding roles option to postgresql_role

### DIFF
--- a/modules/postgresql-flex/README.md
+++ b/modules/postgresql-flex/README.md
@@ -44,6 +44,7 @@ variable "database_roles" {
       name              = "appuser"
       password_override = null # Leave empty
       replication       = false
+      roles             = ["pg_monitor"]
       grants = [
         {
           database    = "mydatabase"

--- a/modules/postgresql-flex/main.tf
+++ b/modules/postgresql-flex/main.tf
@@ -123,7 +123,7 @@ resource "postgresql_role" "roles" {
   inherit             = true
   password            = each.value.password_override != null ? each.value.password_override : random_password.roles[each.key].result
   skip_reassign_owned = true
-  roles               = var.roles_list
+  roles               = each.value.roles
   depends_on = [
     azurerm_postgresql_flexible_server.main,
   ]

--- a/modules/postgresql-flex/main.tf
+++ b/modules/postgresql-flex/main.tf
@@ -123,7 +123,7 @@ resource "postgresql_role" "roles" {
   inherit             = true
   password            = each.value.password_override != null ? each.value.password_override : random_password.roles[each.key].result
   skip_reassign_owned = true
-
+  roles               = var.roles_list
   depends_on = [
     azurerm_postgresql_flexible_server.main,
   ]

--- a/modules/postgresql-flex/variables.tf
+++ b/modules/postgresql-flex/variables.tf
@@ -147,7 +147,7 @@ variable "database_roles" {
       name              = "appuser"
       password_override = null # Password will be generated if left empty
       replication       = false
-      roles             = ["pg_monitor"] # Defines list of roles which will be granted to this new role.
+      roles             = [] # Defines list of roles which will be granted to this new role.
       grants = [
         {
           database    = "application"

--- a/modules/postgresql-flex/variables.tf
+++ b/modules/postgresql-flex/variables.tf
@@ -158,3 +158,9 @@ variable "database_roles" {
     }
   }
 }
+
+variable "roles_list" {
+  description = "List of roles which will be granted to this new role"
+  type        = list
+  default     = ""
+}

--- a/modules/postgresql-flex/variables.tf
+++ b/modules/postgresql-flex/variables.tf
@@ -147,6 +147,7 @@ variable "database_roles" {
       name              = "appuser"
       password_override = null # Password will be generated if left empty
       replication       = false
+      roles             = ["pg_monitor"] # Defines list of roles which will be granted to this new role.
       grants = [
         {
           database    = "application"
@@ -157,10 +158,4 @@ variable "database_roles" {
       ]
     }
   }
-}
-
-variable "roles_list" {
-  description = "List of roles which will be granted to this new role"
-  type        = list
-  default     = ""
 }

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -44,6 +44,7 @@ variable "database_roles" {
       name              = "appuser"
       password_override = null # Leave empty
       replication       = false
+      roles             = ["pg_monitor"]
       grants = [
         {
           database    = "mydatabase"

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -158,7 +158,7 @@ resource "postgresql_role" "roles" {
   inherit             = true
   password            = each.value.password_override != null ? each.value.password_override : random_password.roles[each.key].result
   skip_reassign_owned = true
-
+  roles               = each.value.roles
   depends_on = [
     azurerm_postgresql_server.main,
     time_sleep.wait_for_dns

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -160,7 +160,7 @@ variable "database_roles" {
       name              = "appuser"
       password_override = null # Password will be generated if left empty
       replication       = false
-      roles             = ["pg_monitor"] # Defines list of roles which will be granted to this new role.
+      roles             = [] # Defines list of roles which will be granted to this new role.
       grants = [
         {
           database    = "application"

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -160,6 +160,7 @@ variable "database_roles" {
       name              = "appuser"
       password_override = null # Password will be generated if left empty
       replication       = false
+      roles             = ["pg_monitor"] # Defines list of roles which will be granted to this new role.
       grants = [
         {
           database    = "application"


### PR DESCRIPTION
Adding the roles option to postgresql_role so that the teams would be able to add the required roles via terraform. As today, they add it manually and whenever terraform runs, it will remove the manual added roles. 

https://registry.terraform.io/providers/cyrilgdn/postgresql/latest/docs/resources/postgresql_role
