### PR TITLE
fix: Update version contraint for azurerm provider

### DIFF
--- a/modules/postgresql-flex/README.md
+++ b/modules/postgresql-flex/README.md
@@ -133,7 +133,7 @@ This can be fixed by first deleting the admin password from the Terraform state,
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 2.53.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 2.57 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0.3 |
 | <a name="requirement_postgresql"></a> [postgresql](#requirement\_postgresql) | 1.12.0 |
 
@@ -141,7 +141,7 @@ This can be fixed by first deleting the admin password from the Terraform state,
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 2.53.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 2.57 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.0.3 |
 | <a name="provider_postgresql"></a> [postgresql](#provider\_postgresql) | 1.12.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |

--- a/modules/postgresql-flex/versions.tf
+++ b/modules/postgresql-flex/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 2.53.0"
+      version = "~> 2.57"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
This will change the version contraint for the azurerm provider to allow only new patch releases within minor relase.