### PR TITLE
fix: Make availability zone automatically computed

### DIFF
--- a/modules/postgresql-flex/main.tf
+++ b/modules/postgresql-flex/main.tf
@@ -63,6 +63,9 @@ resource "azurerm_postgresql_flexible_server" "main" {
   tags                   = var.tags
   lifecycle {
     prevent_destroy = true
+    ignore_changes = [
+      zone
+    ]
   }
 }
 


### PR DESCRIPTION
Ignore changes to the zone field since we do not set this in our code.

Ref. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/3.0-upgrade-guide#behavioural-updates